### PR TITLE
refactor: Modify the return type for `Passkey.register` to `PasskeyRegistrationResult` and update types following the w3c specification

### DIFF
--- a/ios/Passkey.swift
+++ b/ios/Passkey.swift
@@ -3,7 +3,7 @@ import AuthenticationServices
 @objc(Passkey)
 class Passkey: NSObject {
   var passKeyDelegate: PasskeyDelegate?;
-  
+
   @objc(register:withChallenge:withDisplayName:withUserId:withSecurityKey:withResolver:withRejecter:)
   func register(_ identifier: String, challenge: String, displayName: String, userId: String, securityKey: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
     // Convert challenge and userId to correct type
@@ -12,11 +12,11 @@ class Passkey: NSObject {
       return;
     }
     let userIdData: Data = RCTConvert.nsData(userId);
-    
-    // Check if Passkeys are supported on this OS versionoiooo
+
+    // Check if Passkeys are supported on this OS version
     if #available(iOS 15.0, *) {
       let authController: ASAuthorizationController;
-      
+
       // Check if registration should proceed with a security key
       if (securityKey) {
         // Create a new registration request with security key
@@ -30,7 +30,7 @@ class Passkey: NSObject {
         let authRequest = platformProvider.createCredentialRegistrationRequest(challenge: challengeData, name: displayName, userID: userIdData);
         authController = ASAuthorizationController(authorizationRequests: [authRequest]);
       }
-      
+
       // Set up a PasskeyDelegate instance with a callback function
       self.passKeyDelegate = PasskeyDelegate { error, result in
         // Check if authorization process returned an error and throw if thats the case
@@ -39,7 +39,7 @@ class Passkey: NSObject {
           reject(passkeyError.rawValue, passkeyError.rawValue, nil);
           return;
         }
-        
+
         // Check if the result object contains a valid registration result
         if let registrationResult = result?.registrationResult {
           // Return a NSDictionary instance with the received authorization data
@@ -47,7 +47,7 @@ class Passkey: NSObject {
             "rawAttestationObject": registrationResult.rawAttestationObject.base64EncodedString(),
             "rawClientDataJSON": registrationResult.rawClientDataJSON.base64EncodedString()
           ];
-          
+
           let authResult: NSDictionary = [
             "credentialID": registrationResult.credentialID.base64EncodedString(),
             "response": authResponse
@@ -58,7 +58,7 @@ class Passkey: NSObject {
           reject(PassKeyError.requestFailed.rawValue, PassKeyError.requestFailed.rawValue, nil);
         }
       }
-      
+
       if let passKeyDelegate = self.passKeyDelegate {
         // Perform the authorization request
         passKeyDelegate.performAuthForController(controller: authController);
@@ -68,7 +68,7 @@ class Passkey: NSObject {
       reject(PassKeyError.notSupported.rawValue, PassKeyError.notSupported.rawValue, nil);
     }
   }
-  
+
   @objc(authenticate:withChallenge:withSecurityKey:withResolver:withRejecter:)
   func authenticate(_ identifier: String, challenge: String, securityKey: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
 
@@ -77,11 +77,11 @@ class Passkey: NSObject {
       reject(PassKeyError.invalidChallenge.rawValue, PassKeyError.invalidChallenge.rawValue, nil);
       return;
     }
-    
+
     // Check if Passkeys are supported on this OS version
     if #available(iOS 15.0, *) {
       let authController: ASAuthorizationController;
-      
+
       // Check if authentication should proceed with a security key
       if (securityKey) {
         // Create a new assertion request with security key
@@ -94,7 +94,7 @@ class Passkey: NSObject {
         let authRequest = platformProvider.createCredentialAssertionRequest(challenge: challengeData);
         authController = ASAuthorizationController(authorizationRequests: [authRequest]);
       }
-      
+
       // Set up a PasskeyDelegate instance with a callback function
       self.passKeyDelegate = PasskeyDelegate { error, result in
         // Check if authorization process returned an error and throw if thats the case
@@ -111,7 +111,7 @@ class Passkey: NSObject {
             "rawClientDataJSON": assertionResult.rawClientDataJSON.base64EncodedString(),
             "signature": assertionResult.signature.base64EncodedString(),
           ];
-          
+
           let authResult: NSDictionary = [
             "credentialID": assertionResult.credentialID.base64EncodedString(),
             "userID": String(decoding: assertionResult.userID, as: UTF8.self),
@@ -123,7 +123,7 @@ class Passkey: NSObject {
           reject(PassKeyError.requestFailed.rawValue, PassKeyError.requestFailed.rawValue, nil);
         }
       }
-      
+
       if let passKeyDelegate = self.passKeyDelegate {
         // Perform the authorization request
         passKeyDelegate.performAuthForController(controller: authController);
@@ -133,7 +133,7 @@ class Passkey: NSObject {
       reject(PassKeyError.notSupported.rawValue, PassKeyError.notSupported.rawValue, nil);
     }
   }
-  
+
   // Handles ASAuthorization error codes
   func handleErrorCode(error: Error) -> PassKeyError {
     let errorCode = (error as NSError).code;

--- a/src/Passkey.tsx
+++ b/src/Passkey.tsx
@@ -17,7 +17,7 @@ export class Passkey {
     { withSecurityKey }: { withSecurityKey: boolean } = {
       withSecurityKey: false,
     }
-  ): Promise<object> {
+  ): Promise<PasskeyRegistrationResult> {
     if (!Passkey.isSupported) {
       throw NotSupportedError;
     }
@@ -77,29 +77,39 @@ export interface PasskeyOptions {
   withSecurityKey: boolean; // iOS only
 }
 
+// https://www.w3.org/TR/webauthn-2/#dictionary-credential-descriptor
+interface PublicKeyCredentialDescriptor {
+  type: string;
+  id: string;
+  transports?: Array<string>;
+}
+
 /**
  * The FIDO2 Attestation Request
+ * https://www.w3.org/TR/webauthn-2/#dictionary-makecredentialoptions
  */
 export interface PasskeyRegistrationRequest {
   challenge: string;
   rp: {
     id: string;
-    name?: string;
+    name: string;
   };
   user: {
     id: string;
-    name?: string;
+    name: string;
     displayName: string;
   };
   pubKeyCredParams: Array<{ type: string; alg: number }>;
-  timeout: number;
-  attestation: string;
-  authenticatorSelection: {
+  timeout?: number;
+  excludeCredentials?: Array<PublicKeyCredentialDescriptor>;
+  authenticatorSelection?: {
     authenticatorAttachment?: string;
     requireResidentKey?: boolean;
     residentKey?: string;
     userVerification?: string;
   };
+  attestation?: string;
+  extensions?: Record<string, unknown>;
 }
 
 /**

--- a/src/Passkey.tsx
+++ b/src/Passkey.tsx
@@ -127,12 +127,15 @@ export interface PasskeyRegistrationResult {
 
 /**
  * The FIDO2 Assertion Request
+ * https://www.w3.org/TR/webauthn-2/#dictionary-assertion-options
  */
 export interface PasskeyAuthenticationRequest {
   challenge: string;
-  timeout: number;
-  userVerification: string;
   rpId: string;
+  timeout?: number;
+  allowCredentials?: Array<PublicKeyCredentialDescriptor>;
+  userVerification?: string;
+  extensions?: Record<string, unknown>;
 }
 
 /**

--- a/src/PasskeyiOS.tsx
+++ b/src/PasskeyiOS.tsx
@@ -18,7 +18,7 @@ export class PasskeyiOS {
   public static async register(
     request: PasskeyRegistrationRequest,
     withSecurityKey = false
-  ): Promise<object> {
+  ): Promise<PasskeyRegistrationResult> {
     // Extract the required data from the attestation request
     const { rpId, challenge, name, userID } =
       this.prepareRegistrationRequest(request);


### PR DESCRIPTION
This PR changes the return type of `Passkey.register` from `Promise<object>`to `Promise<PasskeyRegistrationResult>` in order to get a typed object when invoked.

Additionally, in order to comply with the w3c passkey level 2 specification, this PR also suggests making minor changes to the types `PasskeyRegistrationRequest` and `PasskeyAuthenticationRequest`.

Bonus: Minor typo in the `ios/Passkey.swift` 😛 