### PR TITLE
Feat/allow credential ids

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -302,7 +302,7 @@ PODS:
   - React-jsinspector (0.70.3)
   - React-logger (0.70.3):
     - glog
-  - react-native-passkey (2.0.0):
+  - react-native-passkey (2.1.1):
     - React-Core
   - React-perflogger (0.70.3)
   - React-RCTActionSheet (0.70.3):
@@ -562,7 +562,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 7e2e1772ef7b97168c880eeaf3749d8c145ffd6e
   React-jsinspector: 0553c9fe7218e1f127be070bd5a4d2fc19fb8190
   React-logger: cffcc09e8aba8a3014be8d18da7f922802e9f19e
-  react-native-passkey: 39cbd3e28ecdb1a520f648c480666acc7af48637
+  react-native-passkey: 29ff814a83dfd4311478498e71a801dce68043ac
   React-perflogger: 082b4293f0b3914ff41da35a6c06ac4490fcbcc8
   React-RCTActionSheet: 83da3030deb5dea54b398129f56540a44e64d3ae
   React-RCTAnimation: bac3a4f4c0436554d9f7fbb1352a0cdcb1fb0f1c

--- a/ios/Passkey.m
+++ b/ios/Passkey.m
@@ -3,19 +3,20 @@
 
 @interface RCT_EXTERN_MODULE(Passkey, NSObject)
 
-RCT_EXTERN_METHOD(register:(NSString)identifier
-                  withChallenge:(NSString)challenge
+RCT_EXTERN_METHOD(register:(NSString) identifier
+                  withChallenge:(NSString) challenge
                   withDisplayName:(NSString) displayName
                   withUserId:(NSString) userId
                   withSecurityKey: (BOOL) securityKey
-                  withResolver:(RCTPromiseResolveBlock)resolve
-                  withRejecter:(RCTPromiseRejectBlock)reject);
+                  withResolver:(RCTPromiseResolveBlock) resolve
+                  withRejecter:(RCTPromiseRejectBlock) reject);
 
-RCT_EXTERN_METHOD(authenticate:(NSString)identifier
-                  withChallenge:(NSString)challenge
+RCT_EXTERN_METHOD(authenticate:(NSString) identifier
+                  withChallenge:(NSString) challenge
+                  withCredentialIDs:(NSArray) credentialIDs
                   withSecurityKey:(BOOL) securityKey
-                  withResolver:(RCTPromiseResolveBlock)resolve
-                  withRejecter:(RCTPromiseRejectBlock)reject);
+                  withResolver:(RCTPromiseResolveBlock) resolve
+                  withRejecter:(RCTPromiseRejectBlock) reject);
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/src/Passkey.tsx
+++ b/src/Passkey.tsx
@@ -38,8 +38,9 @@ export class Passkey {
    */
   public static async authenticate(
     request: PasskeyAuthenticationRequest,
-    { withSecurityKey }: { withSecurityKey: boolean } = {
-      withSecurityKey: false,
+    { credentialIDs, withSecurityKey }: PasskeyOptions = {
+      credentialIDs: [],
+      withSecurityKey: false
     }
   ): Promise<PasskeyAuthenticationResult> {
     if (!Passkey.isSupported) {
@@ -49,7 +50,7 @@ export class Passkey {
     if (Platform.OS === 'android') {
       return PasskeyAndroid.authenticate(request);
     }
-    return PasskeyiOS.authenticate(request, withSecurityKey);
+    return PasskeyiOS.authenticate(request, credentialIDs, withSecurityKey);
   }
 
   /**
@@ -73,8 +74,12 @@ export class Passkey {
 /**
  * The available options for Passkey operations
  */
-export interface PasskeyOptions {
-  withSecurityKey: boolean; // iOS only
+export type PasskeyOptions = {
+  credentialIDs?: Array<string>; // iOS only
+  withSecurityKey?: false; // iOS only
+} | {
+  credentialIDs?: never; // iOS only
+  withSecurityKey: true; // iOS only
 }
 
 // https://www.w3.org/TR/webauthn-2/#dictionary-credential-descriptor

--- a/src/PasskeyError.tsx
+++ b/src/PasskeyError.tsx
@@ -29,6 +29,11 @@ export const InvalidChallengeError: PasskeyError = {
   message: 'The provided challenge was invalid',
 };
 
+export const InvalidCredentialIDsError: PasskeyError = {
+  error: 'InvalidCredentialIDs',
+  message: 'The provided credentialIDs were invalid',
+};
+
 export const InvalidUserIdError: PasskeyError = {
   error: 'InvalidUserId',
   message: 'The provided userId was invalid',

--- a/src/PasskeyiOS.tsx
+++ b/src/PasskeyiOS.tsx
@@ -71,17 +71,20 @@ export class PasskeyiOS {
    * iOS implementation of the authentication process
    *
    * @param request The FIDO2 Assertion Request in JSON format
-   * @param withSecurityKey A boolean indicating wether a security key should be used for authentication
+   * @param credentialIDs A string array of allowed passkey credentialIDs
+   * @param withSecurityKey A boolean indicating whether a security key should be used for authentication
    * @returns The FIDO2 Assertion Result in JSON format
    */
   public static async authenticate(
     request: PasskeyAuthenticationRequest,
+    credentialIDs: Array<string> = [],
     withSecurityKey = false
   ): Promise<PasskeyAuthenticationResult> {
     try {
       const response = await NativePasskey.authenticate(
         request.rpId,
         request.challenge,
+        credentialIDs,
         withSecurityKey
       );
       return this.handleNativeAuthenticationResult(response);

--- a/src/__tests__/PasskeyiOS.spec.tsx
+++ b/src/__tests__/PasskeyiOS.spec.tsx
@@ -59,4 +59,16 @@ describe('Test Passkey Module', () => {
     });
     expect(authSpy).toHaveBeenCalled();
   });
+
+  test('should call native auth method with credentialIDs passed', async () => {
+    const authSpy = jest
+      .spyOn(NativeModules.Passkey, 'authenticate')
+      .mockResolvedValue(AuthiOSResult);
+
+    // TODO: test that this is actually only showing the creds specified
+    await Passkey.authenticate(AuthRequest, {
+      credentialIDs: ['wOcpYYrgQyCo7iy9q5IYodwSappmCy-CaXuV7hhKxtQdAAAAAA'],
+    });
+    expect(authSpy).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
# Add `credentialIDs` to iOS api

This pr adds the ability to pass a set of allowed credentialIDs to the iOS `authenticate` function. This enables the developer to force the user to choose a specific passkey when signing in. This is important in a crypto context where passkeys are used as an alternative to a seed phrase. In this situation you want force the user to use a specific key so they don't sign a transaction with the wrong key. But, of course, there are more non-crypto use-cases.

<details>
<summary>
We have been using this patch in production for the past 7 months so I thought it was about time to create a pr!
</summary>

```diff
diff --git a/ios/Passkey.m b/ios/Passkey.m
index 4c50f0d51709d1cb490af4b5c8092fe42cd3c2d9..aa81705149322fb8da2e957ae243c5f89c2bcecc 100644
--- a/ios/Passkey.m
+++ b/ios/Passkey.m
@@ -13,6 +13,7 @@ RCT_EXTERN_METHOD(register:(NSString)identifier
 
 RCT_EXTERN_METHOD(auth:(NSString)identifier
                   withChallenge:(NSString)challenge
+                  withCredentialIDs:(NSArray) credentialIDs
                   withSecurityKey:(BOOL) securityKey
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
diff --git a/ios/Passkey.swift b/ios/Passkey.swift
index ead171651f8ab8ca8f0c9554d28871e4f9c358c6..b754e06e5e07a46e777ec5faf3063b08b4625674 100644
--- a/ios/Passkey.swift
+++ b/ios/Passkey.swift
@@ -69,8 +69,8 @@ class Passkey: NSObject {
     }
   }
   
-  @objc(auth:withChallenge:withSecurityKey:withResolver:withRejecter:)
-  func auth(_ identifier: String, challenge: String, securityKey: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+  @objc(auth:withChallenge:withCredentialIDs:withSecurityKey:withResolver:withRejecter:)
+  func auth(_ identifier: String, challenge: String, credentialIDs: Array<String>, securityKey: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
 
     // Convert challenge to correct type
     guard let challengeData: Data = Data(base64Encoded: challenge) else {
@@ -92,6 +92,18 @@ class Passkey: NSObject {
         // Create a new assertion request without security key
         let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: identifier);
         let authRequest = platformProvider.createCredentialAssertionRequest(challenge: challengeData);
+        if (credentialIDs.isEmpty == false) {
+            var ids: [ASAuthorizationPlatformPublicKeyCredentialDescriptor] = [];
+
+            credentialIDs.forEach { base64Id in 
+              guard let id: Data = Data(base64Encoded: base64Id) 
+              else { return; }
+
+              ids.append(ASAuthorizationPlatformPublicKeyCredentialDescriptor.init(credentialID: id));
+            }
+
+            authRequest.allowedCredentials = ids;
+          }
         authController = ASAuthorizationController(authorizationRequests: [authRequest]);
       }
       
@@ -152,6 +164,7 @@ enum PassKeyError: String, Error {
   case notSupported = "NotSupported"
   case requestFailed = "RequestFailed"
   case cancelled = "UserCancelled"
+  case invalidCredentialId = "InvalidCredentialId"
   case invalidChallenge = "InvalidChallenge"
   case notConfigured = "NotConfigured"
   case unknown = "UnknownError"
diff --git a/lib/commonjs/Passkey.js b/lib/commonjs/Passkey.js
index 59528c08ab4f225e4dbe7df0313a2ddd1f73e621..08630d3367401722fed5411a3b3626584906e14e 100644
--- a/lib/commonjs/Passkey.js
+++ b/lib/commonjs/Passkey.js
@@ -76,7 +76,7 @@ class Passkey {
       throw _PasskeyError.InvalidChallengeError;
     }
     try {
-      return await _NativePasskey.NativePasskey.auth(this.identifier, challenge, (options === null || options === void 0 ? void 0 : options.withSecurityKey) ?? false);
+      return await NativePasskey.auth(this.identifier, challenge, (options === null || options === void 0 ? void 0 : options.credentialIDs) ?? [], (options === null || options === void 0 ? void 0 : options.withSecurityKey) ?? false);
     } catch (error) {
       throw (0, _PasskeyError.handleNativeError)(error);
     }
diff --git a/lib/module/Passkey.js b/lib/module/Passkey.js
index 1f3067d956591b1f3569aa802129fed30d7e06cc..78d830025a165249b59db669888d155279fba021 100644
--- a/lib/module/Passkey.js
+++ b/lib/module/Passkey.js
@@ -70,7 +70,7 @@ export class Passkey {
       throw InvalidChallengeError;
     }
     try {
-      return await NativePasskey.auth(this.identifier, challenge, (options === null || options === void 0 ? void 0 : options.withSecurityKey) ?? false);
+      return await NativePasskey.auth(this.identifier, challenge, (options === null || options === void 0 ? void 0 : options.credentialIDs) ?? [], (options === null || options === void 0 ? void 0 : options.withSecurityKey) ?? false);
     } catch (error) {
       throw handleNativeError(error);
     }
diff --git a/lib/typescript/Passkey.d.ts b/lib/typescript/Passkey.d.ts
index 4c492f5b9dbe5d85d55ea70139a76669c4e8b72a..04305549e889f0c40f4395414927e69469ffe4fe 100644
--- a/lib/typescript/Passkey.d.ts
+++ b/lib/typescript/Passkey.d.ts
@@ -41,7 +41,8 @@ export declare class Passkey {
     static isSupported(): Promise<boolean>;
 }
 export interface PasskeyOptions {
-    withSecurityKey: boolean;
+    credentialIDs?: Array<string>;
+    withSecurityKey?: boolean;
 }
 /**
  * The result of a successful registration request

```
</details>

## Things to note

- We have only ever had a need for **one credentialID at a time** but the api **should** support more. I say this to say that allowing more is untested & I have left a comment to add a todo for this.
- I have updated the types on the `authenticate` function to allow for backwards compatibility with the current api but also to warn the user that using `credentialIDs` & `withSecurityKey` is forbidden for now. This uses a simple discriminated union
- I am not sure how the test are setup (they seem to use a passkey local to the lib author?) but they are passing on my local machine & they could definitely be improved to better test this new functionality! For example, by checking that the specified keys are those that actually show up in the passkey modal.
- I am unfamiliar with Kotlin (& Swift 😅) but happy to dig into the api for this and try adding this for Android too but maybe best to wait until the following api issue is decided on.

## Supporting both `credentialIDs` & `withSecurityKey`

I want to open a discussion around the desired api for combining these two options. How best to design the api is unclear.

To my mind there are two obvious approaches:

 1. Allow each credential to have a specific transport type that you wish to enforce

     ```ts
     export type PasskeyOptions = {
         credentialIDs: Array<string>;
         withSecurityKey?: false;
      } | {
         credentialIDs?: Array<{credentialID: string, transports: Array<AllowedTransports> }>;
         withSecurityKey: true;
      }
     ```

 2. Allow the user to pass acceptable `transports`

     ```ts
      export type PasskeyOptions = {
          credentialIDs: Array<string>;
          withSecurityKey?: false;
       } | {
          credentialIDs?: Array<string>;
          transports?: Array<AllowedTransports>
          withSecurityKey: true;
       }
     ```

### Transport enum choice

For the transports there is also a choice to be made, whether to go with the [Apple naming convention](https://developer.apple.com/documentation/authenticationservices/asauthorizationsecuritykeypublickeycredentialdescriptor/3751836-transports) 

```ts
  export type AllowedTransports = 'nfc' | 'bluetooth' | 'usb' | 'all'
```

Or the [w3c definitions](https://www.w3.org/TR/webauthn-2/#enum-transport)?

```ts
 export type AllowedTransports = 'nfc' | 'ble' | 'internal' | 'usb'
```
