### PR TITLE
fix: Fixed incorrect function invocation that leads to no support check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 
+## [2.1.1](https://github.com/f-23/react-native-passkey/compare/v2.1.0...v2.1.1) (2023-09-13)
+
 # [2.1.0](https://github.com/f-23/react-native-passkey/compare/v2.0.0...v2.1.0) (2023-09-12)
 
 # [2.0.0](https://github.com/f-23/react-native-passkey/compare/v1.1.3...v2.0.0) (2023-05-24)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -132,8 +132,8 @@ dependencies {
     //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   // Android Credentials
-  implementation "androidx.credentials:credentials-play-services-auth:1.2.0-beta03"
-  implementation "androidx.credentials:credentials:1.2.0-beta03"
+  implementation "androidx.credentials:credentials-play-services-auth:1.2.0-rc01"
+  implementation "androidx.credentials:credentials:1.2.0-rc01"
 
   // Kotlin Coroutines
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-passkey",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Passkey implementation for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/Passkey.tsx
+++ b/src/Passkey.tsx
@@ -18,7 +18,7 @@ export class Passkey {
       withSecurityKey: false,
     }
   ): Promise<PasskeyRegistrationResult> {
-    if (!Passkey.isSupported) {
+    if (!Passkey.isSupported()) {
       throw NotSupportedError;
     }
 
@@ -42,7 +42,7 @@ export class Passkey {
       withSecurityKey: false,
     }
   ): Promise<PasskeyAuthenticationResult> {
-    if (!Passkey.isSupported) {
+    if (!Passkey.isSupported()) {
       throw NotSupportedError;
     }
 


### PR DESCRIPTION
In condition function reference is casted to boolean and checked instead of checking the result of the function call. So this condition is always true and device support is not checked