### PR TITLE
Updating to latest androix.credentials library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -132,8 +132,8 @@ dependencies {
     //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   // Android Credentials
-  implementation "androidx.credentials:credentials-play-services-auth:1.2.2"
-  implementation "androidx.credentials:credentials:1.2.2"
+  implementation "androidx.credentials:credentials-play-services-auth:1.3.0-beta02"
+  implementation "androidx.credentials:credentials:1.3.0-beta02"
 
   // Kotlin Coroutines
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -132,12 +132,12 @@ dependencies {
     //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   // Android Credentials
-  implementation "androidx.credentials:credentials-play-services-auth:1.2.0-rc01"
-  implementation "androidx.credentials:credentials:1.2.0-rc01"
+  implementation "androidx.credentials:credentials-play-services-auth:1.2.2"
+  implementation "androidx.credentials:credentials:1.2.2"
 
   // Kotlin Coroutines
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1'
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1'
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/com/reactnativepasskey/PasskeyModule.kt
+++ b/android/src/main/java/com/reactnativepasskey/PasskeyModule.kt
@@ -43,9 +43,10 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
   }
 
   private fun handleRegistrationException(e: CreateCredentialException): String {
+    e.printStackTrace()
     when (e) {
       is CreatePublicKeyCredentialDomException -> {
-        return e.domError.toString()
+        return e.errorMessage.toString()
       }
       is CreateCredentialCancellationException -> {
         return "UserCancelled"
@@ -63,7 +64,7 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
         return "NotSupported"
       }
       else -> {
-        return e.toString()
+        return e.errorMessage.toString()
       }
     }
   }
@@ -89,9 +90,10 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
   }
 
   private fun handleAuthenticationException(e: GetCredentialException): String {
+    e.printStackTrace()
     when (e) {
       is GetPublicKeyCredentialDomException -> {
-        return e.domError.toString()
+        return e.errorMessage.toString()
       }
       is GetCredentialCancellationException -> {
         return "UserCancelled"
@@ -112,7 +114,7 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
         return "NoCredentials"
       }
       else -> {
-        return e.toString()
+        return e.errorMessage.toString()
       }
     }
   }

--- a/src/PasskeyError.tsx
+++ b/src/PasskeyError.tsx
@@ -91,7 +91,7 @@ export function handleNativeError(_error: unknown): PasskeyError {
       return UnknownError;
     }
     default: {
-      return NativeError(error);
+      return NativeError(String(_error));
     }
   }
 }


### PR DESCRIPTION
As experienced in some Android 14 devices, there was an error thrown 
`androidx.credentials.exceptions.CreateCredentialUnsupportedException: Your device doesn't support credential manager` upon credentials registration request, making the registration fail.

Digging up in the Google documentation, I found out that a fallback was introduced in version 1.2.1.

`Provided fallback solution when platform credential manager is not available. ([b/310701473](https://b.corp.google.com/issues/310701473))`

[Google Release Notes](https://developer.android.com/jetpack/androidx/releases/credentials#1.2.1)

Upgrading the library to the latest stable release of androidx.credentials library (1.2.2) fixed the issue.