### PR TITLE
Fix iOS errors

### DIFF
--- a/ios/Passkey.swift
+++ b/ios/Passkey.swift
@@ -276,7 +276,7 @@ class Passkey: NSObject, RNPasskeyResultHandler {
       return
     }
     
-    handler.reject(error.type.rawValue, error.message, nil);
+    handler.reject(error.type.rawValue, error.type.rawValue, nil);
   }
 }
 


### PR DESCRIPTION
Errors from iOS are always reported as `NativeError` instead of specialized cases (e.g. `UserCancelled`)