### PR TITLE
Fixes iOS build failure on Expo SDK 54

### DIFF
--- a/react-native-passkey.podspec
+++ b/react-native-passkey.podspec
@@ -1,7 +1,6 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
   s.name         = "react-native-passkey"
@@ -11,25 +10,21 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "11.0" }
-  s.source       = { :git => "https://github.com/mTRx0/react-native-passkey.git", :tag => "#{s.version}" }
+  # Passkeys need iOS 15+
+  s.platform     = :ios, "15.0"
 
-  s.source_files = "ios/**/*.{h,m,mm,swift}"
+  # When autolinked, CocoaPods will use the local path; the :source is not used.
+  s.source       = { :git => "https://github.com/f-23/react-native-passkey.git", :tag => "v#{s.version}" }
 
-  s.dependency "React-Core"
+  s.source_files  = "ios/**/*.{h,m,mm,swift}"
+  s.swift_version = "5.7"
+  s.frameworks    = "AuthenticationServices"
 
-  # Don't install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+  # Let React Native decide/transitively provide React, Folly, glog, etc.
+  if defined?(install_modules_dependencies)
+    install_modules_dependencies(s)
+  else
+    # Fallback for RN < 0.71
+    s.dependency "React-Core"
   end
 end


### PR DESCRIPTION
**Fix**: Removes direct RCT-Folly/Codegen deps and let RN provide prebuilt deps

### Context
Closes #78. On Expo 54, pod install fails with “Unable to find a specification for RCT-Folly depended upon by react-native-passkey”. SDK 54 ships React Native (and Folly/glog/etc.) as prebuilt XCFrameworks, so third-party pods must not declare those deps directly.

### Changes

- Use install_modules_dependencies(s) for RN ≥ 0.71 so RN supplies React/Folly/glog/…
- Remove explicit deps: RCT-Folly, React-Codegen, RCTRequired, RCTTypeSafety, ReactCommon/turbomodule/core, and Folly compiler flags/header hacks
- Set iOS minimum to 15.0 and add AuthenticationServices framework (passkeys requirement)

### Result
- npx expo prebuild --clean + pod install now succeed on Expo SDK 54
- No Codegen usage required; autolinking remains unchanged

### Backward compatibility
- Fallback keeps s.dependency "React-Core" for RN < 0.71
- Note: raising the iOS deployment target to 15.0 aligns with passkey APIs and may be considered breaking for older iOS targets

### Verify
- New Expo 54 app → install react-native-passkey → npx expo prebuild --clean → npx expo run:ios ✅