### PR TITLE
feat: add CredentialAlreadyExists error for matched excludeCredentials

### DIFF
--- a/android/src/main/java/com/reactnativepasskey/PasskeyModule.kt
+++ b/android/src/main/java/com/reactnativepasskey/PasskeyModule.kt
@@ -10,6 +10,7 @@ import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
 import androidx.credentials.exceptions.*
+import androidx.credentials.exceptions.domerrors.InvalidStateError
 import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException
 import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentialDomException
 
@@ -47,7 +48,14 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
     e.printStackTrace()
     when (e) {
       is CreatePublicKeyCredentialDomException -> {
-        return e.errorMessage.toString()
+        val msg = e.errorMessage?.toString().orEmpty()
+        val isExcludedMatch = e.domError is InvalidStateError &&
+          msg.contains("excluded credential", ignoreCase = true)
+
+        if (isExcludedMatch) {
+          return "CredentialAlreadyExists"
+        }
+        return msg
       }
       is CreateCredentialCancellationException -> {
         return "UserCancelled"

--- a/ios/Passkey.swift
+++ b/ios/Passkey.swift
@@ -308,6 +308,8 @@ class Passkey: NSObject, RNPasskeyResultHandler {
       return RNPasskeyError(type: .timedOut, message: error.localizedDescription);
       case 1:
       return RNPasskeyError(type: .notSupported, message: error.localizedDescription);
+      case 1006:
+      return RNPasskeyError(type: .credentialAlreadyExists, message: error.localizedDescription);
       default:
       return RNPasskeyError(type: .unknown, message: error.localizedDescription);
     }

--- a/ios/PasskeyErrors.swift
+++ b/ios/PasskeyErrors.swift
@@ -21,7 +21,9 @@ enum RNPasskeyErrorType: String {
   case timedOut = "TimedOut"
   
   case HandlerUndefined = "HandlerUndefined"
-  
+
+  case credentialAlreadyExists = "CredentialAlreadyExists"
+
   case unknown = "UnknownError"
   
 }

--- a/src/PasskeyError.ts
+++ b/src/PasskeyError.ts
@@ -54,6 +54,11 @@ export const TimeoutError: PasskeyError = {
   message: 'The operation timed out.',
 };
 
+export const CredentialAlreadyExistsError: PasskeyError = {
+  error: 'CredentialAlreadyExists',
+  message: 'A passkey for this account already exists on this device.',
+};
+
 export const NativeError = (
   message = 'An unknown error occurred'
 ): PasskeyError => {
@@ -96,6 +101,9 @@ export function handleNativeError(_error: TNativeError): PasskeyError {
     }
     case 'TimedOut': {
       return TimeoutError;
+    }
+    case 'CredentialAlreadyExists': {
+      return CredentialAlreadyExistsError;
     }
     case 'UnknownError': {
       return UnknownError;


### PR DESCRIPTION
Fixes #97 

iOS: map ASAuthorizationError 1006 (matchedExcludedCredential, iOS 18+). Android: detect CreatePublicKeyCredentialDomException with InvalidStateError + 'excluded credential' message. JS: add CredentialAlreadyExistsError + handleNativeError case.

Follows the precedent of #86 (UserCancelled for code 1001).