### PR TITLE
fix(ios): base64url-encode userHandle in assertion responses

### DIFF
--- a/ios/PasskeyDelegate.swift
+++ b/ios/PasskeyDelegate.swift
@@ -168,7 +168,7 @@ class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate, ASAuthorizat
     }
     
     let clientExtensionResults = (largeBlob != nil || prf != nil) ? AuthenticationExtensionsClientOutputsJSON(largeBlob: largeBlob, prf: prf) : nil;
-    let userHandle: String? = credential.userID.flatMap { String(data: $0, encoding: .utf8) };
+    let userHandle: String? = credential.userID?.toBase64URLEncodedString();
 
     let response = AuthenticatorAssertionResponseJSON(
         authenticatorData: credential.rawAuthenticatorData.toBase64URLEncodedString(),
@@ -188,7 +188,7 @@ class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate, ASAuthorizat
   }
   
   func handleSecurityKeyPublicKeyAssertionResponse(credential: ASAuthorizationSecurityKeyPublicKeyCredentialAssertion) -> Void {
-    let userHandle: String? = credential.userID.flatMap { String(data: $0, encoding: .utf8) };
+    let userHandle: String? = credential.userID?.toBase64URLEncodedString();
     
     let response =  AuthenticatorAssertionResponseJSON(
       authenticatorData: credential.rawAuthenticatorData.toBase64URLEncodedString(),


### PR DESCRIPTION
## Summary

Fixes #102 — assertion-encode mirror of the registration-decode bug fixed by #90 in 3.3.3.

`ios/PasskeyDelegate.swift` UTF-8-decoded `credential.userID` raw bytes when building the WebAuthn assertion response, instead of base64url-encoding them. The WebAuthn JSON serialization spec requires `userHandle` to be a base64url-encoded `BufferSource`. Both regular passkey and security key paths are affected.

## Diff

```swift
- let userHandle: String? = credential.userID.flatMap { String(data: $0, encoding: .utf8) };
+ let userHandle: String? = credential.userID?.toBase64URLEncodedString();
```

Applied at:
- `ios/PasskeyDelegate.swift:171` — `handlePlatformPublicKeyAssertionResponse`
- `ios/PasskeyDelegate.swift:191` — `handleSecurityKeyPublicKeyAssertionResponse`

Every other binary field in the same file (`credentialID`, `signature`, `rawAuthenticatorData`, `clientDataJSON`) already uses the `Data.toBase64URLEncodedString()` extension from `ios/PasskeyHelper.swift`. `userHandle` was the lone exception.

## Test plan

- [x] Repro confirmed on 3.3.3: backend's base64url decode of `userHandle` throws `IllegalArgumentException` when `user.id` is ASCII (e.g. numeric account ID `565388025` → 9 chars, invalid base64url length).
- [x] After patch: assertion JSON `userHandle` is a valid base64url string that round-trips with the `user.id` set at registration.

Happy to add iOS unit tests if you'd like — there are no existing tests for assertion-response handling so I left this PR minimal.

## Notes

This complements #90. The same architectural mistake (UTF-8 ↔ base64url confusion) existed on both inbound (registration `user.id`) and outbound (assertion `userHandle`) sides. #90 fixed the inbound; this fixes the outbound. After this PR, all `Data ↔ String` conversions in the iOS bridge consistently use `Data.toBase64URLEncodedString()` and `Data(base64URLEncoded:)`.
