### PR TITLE
Fix Android PRF WebAuthn JSON serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ You can find information on the largeBlob extension in the WebAuthn specificatio
 
 As of version 3.3 the PRF extension will work for Android and iOS 18+.
 
+On Android, binary extension inputs are sent to Credential Manager as standard WebAuthn JSON. You can pass PRF salts as a `Uint8Array`, `ArrayBuffer`, `number[]`, or a Base64URL string; the library normalizes them to Base64URL before calling the native Android API. This avoids Android rejecting otherwise valid PRF creation requests with `No create options available`.
+
 ##### Example
 
 You can use the PRF extension to retrieve a secret which allows for various use cases like encryption of user data.
@@ -303,8 +305,8 @@ You can do this either when creating or when asserting the passkey.
   extensions: {
     prf: {
       eval: {
-        first: Uint8Array<ArrayBuffer>
-        second: Uint8Array<ArrayBuffer> // optional
+        first: Uint8Array | ArrayBuffer | number[] | string
+        second: Uint8Array | ArrayBuffer | number[] | string // optional
       }
     }
   }

--- a/src/Passkey.ts
+++ b/src/Passkey.ts
@@ -10,6 +10,7 @@ import type {
   PasskeyGetRequest,
   PasskeyGetResult,
 } from './PasskeyTypes';
+import { stringifyPasskeyRequest } from './PasskeyRequest';
 import { NativePasskey } from './NativePasskey';
 
 export class Passkey {
@@ -30,7 +31,7 @@ export class Passkey {
 
     try {
       const response = await NativePasskey.create(
-        JSON.stringify(request),
+        stringifyPasskeyRequest(request, Platform.OS),
         false, // forcePlatformKey
         false // forceSecurityKey
       );
@@ -62,7 +63,7 @@ export class Passkey {
 
     try {
       const response = await NativePasskey.create(
-        JSON.stringify(request),
+        stringifyPasskeyRequest(request, Platform.OS),
         true, // forcePlatformKey
         false // forceSecurityKey
       );
@@ -94,7 +95,7 @@ export class Passkey {
 
     try {
       const response = await NativePasskey.create(
-        JSON.stringify(request),
+        stringifyPasskeyRequest(request, Platform.OS),
         false, // forcePlatformKey
         true // forceSecurityKey
       );
@@ -125,7 +126,7 @@ export class Passkey {
 
     try {
       const response = await NativePasskey.get(
-        JSON.stringify(request),
+        stringifyPasskeyRequest(request, Platform.OS),
         false, // forcePlatformKey
         false // forceSecurityKey
       );
@@ -157,7 +158,7 @@ export class Passkey {
 
     try {
       const response = await NativePasskey.get(
-        JSON.stringify(request),
+        stringifyPasskeyRequest(request, Platform.OS),
         true, // forcePlatformKey
         false // forceSecurityKey
       );
@@ -189,7 +190,7 @@ export class Passkey {
 
     try {
       const response = await NativePasskey.get(
-        JSON.stringify(request),
+        stringifyPasskeyRequest(request, Platform.OS),
         false, // forcePlatformKey
         true // forceSecurityKey
       );

--- a/src/PasskeyRequest.ts
+++ b/src/PasskeyRequest.ts
@@ -1,0 +1,234 @@
+import type {
+  AuthenticationExtensionsPRFValues,
+  PasskeyCreateRequest,
+  PasskeyGetRequest,
+} from './PasskeyTypes';
+
+type PasskeyRequest = PasskeyCreateRequest | PasskeyGetRequest;
+type EvalByCredential =
+  | Record<string, AuthenticationExtensionsPRFValues>
+  | Array<Record<string, AuthenticationExtensionsPRFValues>>;
+type BinaryInput =
+  | ArrayBuffer
+  | ArrayLike<number>
+  | Record<string, number>
+  | string;
+
+const base64UrlChars =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+export function stringifyPasskeyRequest(
+  request: PasskeyRequest,
+  platformOS: string
+): string {
+  if (platformOS !== 'android') {
+    return JSON.stringify(request);
+  }
+
+  return JSON.stringify(normalizeAndroidRequest(request));
+}
+
+function normalizeAndroidRequest<T extends PasskeyRequest>(request: T): T {
+  const normalized = {
+    ...request,
+    challenge: normalizeBase64UrlString(request.challenge),
+  };
+
+  if (isCreateRequest(request)) {
+    return {
+      ...normalized,
+      user: {
+        ...request.user,
+        id: normalizeBase64UrlString(request.user.id),
+      },
+      excludeCredentials: request.excludeCredentials?.map(
+        normalizeCredentialDescriptor
+      ),
+      extensions: normalizeExtensions(request.extensions),
+    } as T;
+  }
+
+  return {
+    ...normalized,
+    allowCredentials: request.allowCredentials?.map(
+      normalizeCredentialDescriptor
+    ),
+    extensions: normalizeExtensions(request.extensions),
+  } as T;
+}
+
+function isCreateRequest(
+  request: PasskeyRequest
+): request is PasskeyCreateRequest {
+  return 'user' in request;
+}
+
+function normalizeCredentialDescriptor<
+  T extends NonNullable<
+    | PasskeyCreateRequest['excludeCredentials']
+    | PasskeyGetRequest['allowCredentials']
+  >[number]
+>(credential: T): T {
+  return {
+    ...credential,
+    id: normalizeBase64UrlString(credential.id),
+  };
+}
+
+function normalizeExtensions<
+  T extends PasskeyCreateRequest['extensions'] | PasskeyGetRequest['extensions']
+>(extensions: T): T {
+  if (!extensions) {
+    return extensions;
+  }
+
+  return {
+    ...extensions,
+    largeBlob: extensions.largeBlob
+      ? {
+          ...extensions.largeBlob,
+          write:
+            extensions.largeBlob.write === undefined
+              ? undefined
+              : binaryInputToBase64Url(extensions.largeBlob.write),
+        }
+      : undefined,
+    prf: extensions.prf
+      ? {
+          ...extensions.prf,
+          eval: normalizePrfValues(extensions.prf.eval),
+          evalByCredential: normalizeEvalByCredential(
+            extensions.prf.evalByCredential
+          ),
+        }
+      : undefined,
+  } as T;
+}
+
+function normalizePrfValues<
+  T extends NonNullable<
+    NonNullable<PasskeyCreateRequest['extensions']>['prf']
+  >['eval']
+>(values: T): T {
+  if (!values) {
+    return values;
+  }
+
+  return {
+    ...values,
+    first: binaryInputToBase64Url(values.first),
+    second:
+      values.second === undefined
+        ? undefined
+        : binaryInputToBase64Url(values.second),
+  } as T;
+}
+
+function normalizeEvalByCredential(
+  evalByCredential: EvalByCredential | undefined
+): EvalByCredential | undefined {
+  if (!evalByCredential) {
+    return evalByCredential;
+  }
+
+  if (Array.isArray(evalByCredential)) {
+    return evalByCredential.map(normalizeEvalByCredentialRecord);
+  }
+
+  return normalizeEvalByCredentialRecord(evalByCredential);
+}
+
+function normalizeEvalByCredentialRecord(
+  evalByCredential: Record<string, AuthenticationExtensionsPRFValues>
+): Record<string, AuthenticationExtensionsPRFValues> {
+  return Object.fromEntries(
+    Object.entries(evalByCredential).map(([credentialId, values]) => [
+      normalizeBase64UrlString(credentialId),
+      normalizePrfValues(values),
+    ])
+  );
+}
+
+function binaryInputToBase64Url(value: BinaryInput): string {
+  if (typeof value === 'string') {
+    return normalizeBase64UrlString(value);
+  }
+
+  if (isArrayBuffer(value)) {
+    return bytesToBase64Url(new Uint8Array(value));
+  }
+
+  if (isArrayBufferView(value)) {
+    return bytesToBase64Url(
+      new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+    );
+  }
+
+  if (Array.isArray(value)) {
+    return bytesToBase64Url(value);
+  }
+
+  if (isNumberRecord(value)) {
+    return bytesToBase64Url(
+      Object.entries(value)
+        .sort(([left], [right]) => Number(left) - Number(right))
+        .map(([, byte]) => byte)
+    );
+  }
+
+  return bytesToBase64Url(Array.from(value));
+}
+
+function normalizeBase64UrlString(value: string): string {
+  return value.replace(/\+/g, '-').replace(/\//g, '_').replace(/[=]+$/g, '');
+}
+
+function bytesToBase64Url(bytes: ArrayLike<number>): string {
+  let encoded = '';
+
+  for (let index = 0; index < bytes.length; index += 3) {
+    const first = bytes[index] ?? 0;
+    const second = bytes[index + 1] ?? 0;
+    const third = bytes[index + 2] ?? 0;
+
+    encoded += base64UrlChars[first >> 2];
+    encoded += base64UrlChars[((first & 3) << 4) | (second >> 4)];
+
+    if (index + 1 < bytes.length) {
+      encoded += base64UrlChars[((second & 15) << 2) | (third >> 6)];
+    }
+
+    if (index + 2 < bytes.length) {
+      encoded += base64UrlChars[third & 63];
+    }
+  }
+
+  return encoded;
+}
+
+function isArrayBuffer(value: unknown): value is ArrayBuffer {
+  return typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer;
+}
+
+function isArrayBufferView(value: unknown): value is ArrayBufferView {
+  return (
+    typeof ArrayBuffer !== 'undefined' &&
+    ArrayBuffer.isView(value) &&
+    'buffer' in value &&
+    value.buffer instanceof ArrayBuffer
+  );
+}
+
+function isNumberRecord(value: unknown): value is Record<string, number> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const entries = Object.entries(value);
+  return (
+    entries.length > 0 &&
+    entries.every(
+      ([key, entryValue]) => /^\d+$/.test(key) && typeof entryValue === 'number'
+    )
+  );
+}

--- a/src/PasskeyTypes.ts
+++ b/src/PasskeyTypes.ts
@@ -2,6 +2,8 @@
  * The FIDO2 Attestation Request
  * https://www.w3.org/TR/webauthn-3/#dictionary-makecredentialoptions
  */
+export type PasskeyBinaryValue = Uint8Array | ArrayBuffer | number[] | string;
+
 export interface PasskeyCreateRequest {
   challenge: string;
   rp: {
@@ -27,11 +29,13 @@ export interface PasskeyCreateRequest {
     largeBlob?: {
       support?: 'preferred' | 'required';
       read?: boolean;
-      write?: Uint8Array;
+      write?: PasskeyBinaryValue;
     };
     prf?: {
       eval?: AuthenticationExtensionsPRFValues;
-      evalByCredential?: [string: AuthenticationExtensionsPRFValues];
+      evalByCredential?:
+        | Record<string, AuthenticationExtensionsPRFValues>
+        | Array<Record<string, AuthenticationExtensionsPRFValues>>;
     };
   };
 }
@@ -79,11 +83,13 @@ export interface PasskeyGetRequest {
   extensions?: {
     largeBlob?: {
       read?: boolean;
-      write?: Uint8Array;
+      write?: PasskeyBinaryValue;
     };
     prf?: {
       eval?: AuthenticationExtensionsPRFValues;
-      evalByCredential?: [string: AuthenticationExtensionsPRFValues];
+      evalByCredential?:
+        | Record<string, AuthenticationExtensionsPRFValues>
+        | Array<Record<string, AuthenticationExtensionsPRFValues>>;
     };
   };
 }
@@ -137,6 +143,6 @@ export enum AuthenticatorTransport {
  * https://www.w3.org/TR/webauthn-3/#prf-extension
  */
 export interface AuthenticationExtensionsPRFValues {
-  first: Uint8Array;
-  second?: Uint8Array;
+  first: PasskeyBinaryValue;
+  second?: PasskeyBinaryValue;
 }

--- a/src/__tests__/PasskeyAndroid.spec.ts
+++ b/src/__tests__/PasskeyAndroid.spec.ts
@@ -33,6 +33,45 @@ describe('Test Passkey Module', () => {
     expect(registerSpy).toHaveBeenCalled();
   });
 
+  test('should serialize Android PRF inputs as WebAuthn JSON', async () => {
+    const registerSpy = jest
+      .spyOn(NativeModules.Passkey, 'create')
+      .mockResolvedValue(JSON.stringify(RegAndroidResult));
+
+    await Passkey.create({
+      ...RegRequest,
+      excludeCredentials: [
+        {
+          id: 'wtHzWP5Mav6bQ+CH2241jg==',
+          type: 'public-key',
+        },
+      ],
+      extensions: {
+        prf: {
+          eval: {
+            first: new Uint8Array([
+              118, 50, 79, 56, 70, 82, 83, 95, 51, 78, 70, 118, 111, 104, 111,
+              48, 51, 119, 87, 108, 79, 101, 109, 55, 111, 118, 65, 48, 79, 82,
+              49, 76,
+            ]),
+          },
+        },
+      },
+    });
+
+    const nativeCall =
+      registerSpy.mock.calls[registerSpy.mock.calls.length - 1];
+    expect(nativeCall).toBeDefined();
+
+    const nativeRequest = JSON.parse(nativeCall?.[0] as string);
+    expect(nativeRequest.extensions.prf.eval.first).toBe(
+      'djJPOEZSU18zTkZ2b2hvMDN3V2xPZW03b3ZBME9SMUw'
+    );
+    expect(nativeRequest.excludeCredentials[0].id).toBe(
+      'wtHzWP5Mav6bQ-CH2241jg'
+    );
+  });
+
   test('should call native auth method', async () => {
     const authSpy = jest
       .spyOn(NativeModules.Passkey, 'get')


### PR DESCRIPTION
## Summary
- normalize Android passkey create/get requests into standard WebAuthn JSON before calling Credential Manager
- convert PRF and largeBlob binary extension inputs to Base64URL strings for Android while preserving existing iOS request behavior
- document Android PRF salt input handling and add a regression test for the failing salt from issue #101

## Root cause
Android Credential Manager expects `CreatePublicKeyCredentialRequest` request JSON to contain WebAuthn JSON binary fields as Base64URL strings. React Native callers can pass PRF salts as `Uint8Array`, which `JSON.stringify` serializes into object-like data instead of Base64URL strings. Some salts then cause Android providers to reject the create request with `No create options available`.

Fixes #101

## Validation
- `yarn test --runInBand`
- `yarn typescript`
- `yarn eslint src/Passkey.ts src/PasskeyTypes.ts src/PasskeyRequest.ts src/__tests__/PasskeyAndroid.spec.ts`

Note: full `yarn lint` still reports existing repo-wide CRLF/prettier errors in untouched files.