### PR TITLE
feat: add WebAuthn Signal API (signalUnknownCredential, signalAllAcceptedCredentials)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,57 @@ try {
 }
 ```
 
+#### Signal API
+
+The [WebAuthn Signal API](https://w3c.github.io/webauthn/#sctn-signal-methods)
+lets your app keep OS credential managers (e.g. iCloud Keychain, Google Password
+Manager) in sync with your server. When the server has revoked or deleted a
+passkey, signalling it removes / hides the stale credential so it no longer shows
+up in the system sheet.
+
+Both methods are **best-effort**: they resolve once the request is accepted and
+**no-op** on OS versions without Signal API support (iOS < 26). All credential ids
+and the user handle are passed as Base64URL encoded strings.
+
+- iOS 26+: uses `ASCredentialUpdater`
+- Android: uses `CredentialManager.signalCredentialState` (requires
+  `androidx.credentials` 1.6.0+, bundled with the library)
+
+##### `Passkey.signalUnknownCredential()`
+
+Reports a single credential the relying party no longer recognizes. Use this when
+**unauthenticated** (e.g. after a failed sign-in): it takes a single credential id
+and no user handle, so it reveals nothing about the user.
+
+```ts
+import { Passkey } from 'react-native-passkey';
+
+// e.g. after the server rejects the credential used to authenticate
+await Passkey.signalUnknownCredential({
+  rpId: 'example.com',
+  credentialId, // Base64URL encoded credential id
+});
+```
+
+##### `Passkey.signalAllAcceptedCredentials()`
+
+Reports the complete set of credential ids the relying party still accepts for a
+user. OS credential managers remove / hide any stored credentials **not** in the
+list (reversible — re-signal an id to restore it; an empty list hides all). Use
+this when **authenticated** (after login, or after adding / deleting a passkey):
+it needs the user handle and the full accepted set, so it authoritatively prunes.
+
+```ts
+import { Passkey } from 'react-native-passkey';
+
+// e.g. after deleting a passkey, signal the remaining accepted credentials
+await Passkey.signalAllAcceptedCredentials({
+  rpId: 'example.com',
+  userId, // Base64URL encoded WebAuthn user handle
+  allAcceptedCredentialIds, // string[] of Base64URL encoded credential ids
+});
+```
+
 #### Error codes
 
 The library normalises native error codes into the following set:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -132,8 +132,11 @@ dependencies {
     //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   // Android Credentials
-  implementation "androidx.credentials:credentials-play-services-auth:1.5.0"
-  implementation "androidx.credentials:credentials:1.5.0"
+  // 1.6.0 provides the WebAuthn Signal API (SignalUnknownCredentialRequest /
+  // SignalAllAcceptedCredentialIdsRequest) used by signalUnknownCredential /
+  // signalAllAcceptedCredentials below.
+  implementation "androidx.credentials:credentials-play-services-auth:1.6.0"
+  implementation "androidx.credentials:credentials:1.6.0"
 
   // Kotlin Coroutines
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2'

--- a/android/src/main/java/com/reactnativepasskey/PasskeyModule.kt
+++ b/android/src/main/java/com/reactnativepasskey/PasskeyModule.kt
@@ -9,6 +9,8 @@ import androidx.credentials.CredentialManager
 import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.SignalAllAcceptedCredentialIdsRequest
+import androidx.credentials.SignalUnknownCredentialRequest
 import androidx.credentials.exceptions.*
 import androidx.credentials.exceptions.domerrors.*
 import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException
@@ -17,6 +19,9 @@ import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentia
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+
+import org.json.JSONArray
+import org.json.JSONObject
 
 class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
   private val mainScope = CoroutineScope(Dispatchers.Default)
@@ -100,6 +105,65 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
           promise.reject(errorCode, errorCode)
         }
       }
+  }
+
+  /**
+   * WebAuthn Signal API: tells OS credential managers a credential the relying party no longer
+   * recognizes should be removed/hidden. `credentialId` is a base64url string; the platform
+   * decodes it. Best-effort — resolves once the request is accepted.
+   *
+   * Use when unauthenticated / after a failed sign-in (single credential, no user handle). For the
+   * authenticated full-set reconcile, use [signalAllAcceptedCredentials] instead.
+   */
+  @ReactMethod
+  fun signalUnknownCredential(rpId: String, credentialId: String, promise: Promise) {
+    val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
+    val requestJson = JSONObject().apply {
+      put("rpId", rpId)
+      put("credentialId", credentialId)
+    }.toString()
+
+    mainScope.launch {
+      try {
+        credentialManager.signalCredentialState(SignalUnknownCredentialRequest(requestJson))
+        promise.resolve(null)
+      } catch (e: Exception) {
+        promise.reject("SignalFailed", e.message ?: "signalUnknownCredential failed", e)
+      }
+    }
+  }
+
+  /**
+   * WebAuthn Signal API: reports the complete set of credential ids the relying party still
+   * accepts for (rpId, userId); the credential manager removes any stored credentials not in the
+   * list. `userId` and the ids are base64url strings. `allAcceptedCredentialIdsJson` is a
+   * JSON-encoded array of base64url credential ids.
+   *
+   * Use when authenticated (needs the user handle + full accepted set); authoritatively prunes.
+   * For a single credential when unauthenticated, use [signalUnknownCredential] instead.
+   */
+  @ReactMethod
+  fun signalAllAcceptedCredentials(
+    rpId: String,
+    userId: String,
+    allAcceptedCredentialIdsJson: String,
+    promise: Promise
+  ) {
+    val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
+    val requestJson = JSONObject().apply {
+      put("rpId", rpId)
+      put("userId", userId)
+      put("allAcceptedCredentialIds", JSONArray(allAcceptedCredentialIdsJson))
+    }.toString()
+
+    mainScope.launch {
+      try {
+        credentialManager.signalCredentialState(SignalAllAcceptedCredentialIdsRequest(requestJson))
+        promise.resolve(null)
+      } catch (e: Exception) {
+        promise.reject("SignalFailed", e.message ?: "signalAllAcceptedCredentials failed", e)
+      }
+    }
   }
 
   private fun handleAuthenticationException(e: GetCredentialException): String {

--- a/ios/Passkey.m
+++ b/ios/Passkey.m
@@ -16,6 +16,17 @@ RCT_EXTERN_METHOD(get:(NSString)request
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
 
+RCT_EXTERN_METHOD(signalUnknownCredential:(NSString)rpId
+                  withCredentialId:(NSString)credentialId
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject);
+
+RCT_EXTERN_METHOD(signalAllAcceptedCredentials:(NSString)rpId
+                  withUserId:(NSString)userId
+                  withAllAcceptedCredentialIdsJson:(NSString)allAcceptedCredentialIdsJson
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject);
+
 + (BOOL)requiresMainQueueSetup
 {
   return NO;

--- a/ios/Passkey.swift
+++ b/ios/Passkey.swift
@@ -98,6 +98,82 @@ class Passkey: NSObject, RNPasskeyResultHandler {
     }
   }
   
+  /**
+   WebAuthn Signal API: report a credential the relying party no longer recognizes so the
+   system removes/hides it. `credentialId` is base64url. No-ops below iOS 26 (ASCredentialUpdater
+   is unavailable). Best-effort: resolves once the request is accepted.
+
+   Use when unauthenticated / after a failed sign-in (single credential, no user handle). For the
+   authenticated full-set reconcile, use `signalAllAcceptedCredentials` instead.
+   */
+  @objc(signalUnknownCredential:withCredentialId:withResolver:withRejecter:)
+  func signalUnknownCredential(_ rpId: String, credentialId: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+    guard #available(iOS 26.0, *) else {
+      resolve(nil);
+      return;
+    }
+    guard let credentialIDData: Data = Data(base64URLEncoded: credentialId) else {
+      reject("InvalidCredentialId", "credentialId is not valid base64url", nil);
+      return;
+    }
+    Task {
+      do {
+        try await ASCredentialUpdater().reportUnknownPublicKeyCredential(
+          relyingPartyIdentifier: rpId,
+          credentialID: credentialIDData
+        );
+        resolve(nil);
+      } catch {
+        reject("SignalFailed", error.localizedDescription, error);
+      }
+    }
+  }
+
+  /**
+   WebAuthn Signal API: report the complete set of credential ids the relying party still accepts
+   for (rpId, userId); the system removes any stored credentials not in the list. `userId` is
+   base64url and `allAcceptedCredentialIdsJson` is a JSON-encoded array of base64url ids. No-ops
+   below iOS 26.
+
+   Use when authenticated (needs the user handle + full accepted set); authoritatively prunes.
+   For a single credential when unauthenticated, use `signalUnknownCredential` instead.
+   */
+  @objc(signalAllAcceptedCredentials:withUserId:withAllAcceptedCredentialIdsJson:withResolver:withRejecter:)
+  func signalAllAcceptedCredentials(_ rpId: String, userId: String, allAcceptedCredentialIdsJson: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+    guard #available(iOS 26.0, *) else {
+      resolve(nil);
+      return;
+    }
+    guard let userHandle: Data = Data(base64URLEncoded: userId) else {
+      reject("InvalidUserId", "userId is not valid base64url", nil);
+      return;
+    }
+    guard let idStrings = try? JSONDecoder().decode([String].self, from: Data(allAcceptedCredentialIdsJson.utf8)) else {
+      reject("InvalidCredentialIds", "allAcceptedCredentialIds is not a valid JSON array", nil);
+      return;
+    }
+    var acceptedCredentialIDs: [Data] = [];
+    for id in idStrings {
+      guard let data: Data = Data(base64URLEncoded: id) else {
+        reject("InvalidCredentialId", "an accepted credential id is not valid base64url", nil);
+        return;
+      }
+      acceptedCredentialIDs.append(data);
+    }
+    Task {
+      do {
+        try await ASCredentialUpdater().reportAllAcceptedPublicKeyCredentials(
+          relyingPartyIdentifier: rpId,
+          userHandle: userHandle,
+          acceptedCredentialIDs: acceptedCredentialIDs
+        );
+        resolve(nil);
+      } catch {
+        reject("SignalFailed", error.localizedDescription, error);
+      }
+    }
+  }
+
   func onSuccess(_ data: PublicKeyCredentialJSON) {
     guard let handler = passkeyHandler else {
       print("passkeyHandler was nil");

--- a/src/Passkey.ts
+++ b/src/Passkey.ts
@@ -9,6 +9,8 @@ import type {
   PasskeyCreateResult,
   PasskeyGetRequest,
   PasskeyGetResult,
+  PasskeySignalUnknownCredentialRequest,
+  PasskeySignalAllAcceptedCredentialsRequest,
 } from './PasskeyTypes';
 import { stringifyPasskeyRequest } from './PasskeyRequest';
 import { NativePasskey } from './NativePasskey';
@@ -242,6 +244,60 @@ export class Passkey {
     } catch (error: unknown) {
       throw handleNativeError(error as TNativeError);
     }
+  }
+
+  /**
+   * Reports a credential the relying party no longer recognizes so OS credential
+   * managers can remove / hide it (WebAuthn Signal API).
+   *
+   * Use this when **unauthenticated** (e.g. after a failed sign-in): it takes a
+   * single credential id and no user handle, so it reveals nothing about the user.
+   * For the authenticated full-set reconcile, use `signalAllAcceptedCredentials`
+   * instead.
+   *
+   * This is best-effort and resolves once the request is accepted. It no-ops on OS
+   * versions without Signal API support (iOS < 26).
+   *
+   * @param request The relying party id and the base64URL encoded credential id
+   * @returns A Promise that resolves once the signal has been delivered
+   * @throws
+   */
+  public static async signalUnknownCredential(
+    request: PasskeySignalUnknownCredentialRequest
+  ): Promise<void> {
+    return NativePasskey.signalUnknownCredential(
+      request.rpId,
+      request.credentialId
+    );
+  }
+
+  /**
+   * Reports the complete set of credential ids the relying party still accepts for
+   * a given user (WebAuthn Signal API). OS credential managers remove / hide any
+   * stored credentials not in the list (reversible — re-add an id to restore; an
+   * empty list hides all).
+   *
+   * Use this when **authenticated** (after login, or after adding / deleting a
+   * passkey): it needs the user handle and the full accepted set, so it
+   * authoritatively prunes. For a single credential when unauthenticated, use
+   * `signalUnknownCredential` instead.
+   *
+   * This is best-effort and resolves once the request is accepted. It no-ops on OS
+   * versions without Signal API support (iOS < 26).
+   *
+   * @param request The relying party id, the base64URL encoded user handle and the
+   * base64URL encoded credential ids still accepted by the server
+   * @returns A Promise that resolves once the signal has been delivered
+   * @throws
+   */
+  public static async signalAllAcceptedCredentials(
+    request: PasskeySignalAllAcceptedCredentialsRequest
+  ): Promise<void> {
+    return NativePasskey.signalAllAcceptedCredentials(
+      request.rpId,
+      request.userId,
+      JSON.stringify(request.allAcceptedCredentialIds)
+    );
   }
 
   /**

--- a/src/PasskeyTypes.ts
+++ b/src/PasskeyTypes.ts
@@ -123,6 +123,29 @@ export interface PasskeyGetResult {
   };
 }
 
+/**
+ * The Signal API request reporting a credential the relying party no longer recognizes
+ * https://www.w3.org/TR/webauthn-3/#sctn-signalUnknownCredential
+ */
+export interface PasskeySignalUnknownCredentialRequest {
+  rpId: string;
+  // base64url-encoded credential id
+  credentialId: string;
+}
+
+/**
+ * The Signal API request reporting the complete set of credential ids the relying party
+ * still accepts for a given user
+ * https://www.w3.org/TR/webauthn-3/#sctn-signalAllAcceptedCredentials
+ */
+export interface PasskeySignalAllAcceptedCredentialsRequest {
+  rpId: string;
+  // base64url-encoded WebAuthn user handle
+  userId: string;
+  // array of base64url-encoded credential ids
+  allAcceptedCredentialIds: string[];
+}
+
 // https://www.w3.org/TR/webauthn-3/#dictionary-credential-descriptor
 export interface PublicKeyCredentialDescriptor {
   type: 'public-key';

--- a/src/__mocks__/react-native.js
+++ b/src/__mocks__/react-native.js
@@ -29,6 +29,8 @@ const NativeModules = {
   Passkey: {
     create: jest.fn(),
     get: jest.fn(),
+    signalUnknownCredential: jest.fn(),
+    signalAllAcceptedCredentials: jest.fn(),
   },
 };
 

--- a/src/__tests__/PasskeyAndroid.spec.ts
+++ b/src/__tests__/PasskeyAndroid.spec.ts
@@ -95,4 +95,33 @@ describe('Test Passkey Module', () => {
       true
     );
   });
+
+  test('should call native signalUnknownCredential method', async () => {
+    const signalSpy = jest
+      .spyOn(NativeModules.Passkey, 'signalUnknownCredential')
+      .mockResolvedValue(undefined);
+
+    await Passkey.signalUnknownCredential({
+      rpId: 'example.com',
+      credentialId: 'Y3JlZA',
+    });
+    expect(signalSpy).toHaveBeenCalledWith('example.com', 'Y3JlZA');
+  });
+
+  test('should call native signalAllAcceptedCredentials method with stringified ids', async () => {
+    const signalSpy = jest
+      .spyOn(NativeModules.Passkey, 'signalAllAcceptedCredentials')
+      .mockResolvedValue(undefined);
+
+    await Passkey.signalAllAcceptedCredentials({
+      rpId: 'example.com',
+      userId: 'dXNlcg',
+      allAcceptedCredentialIds: ['a', 'b'],
+    });
+    expect(signalSpy).toHaveBeenCalledWith(
+      'example.com',
+      'dXNlcg',
+      JSON.stringify(['a', 'b'])
+    );
+  });
 });

--- a/src/__tests__/PasskeyiOS.spec.ts
+++ b/src/__tests__/PasskeyiOS.spec.ts
@@ -56,4 +56,33 @@ describe('Test Passkey Module', () => {
       true
     );
   });
+
+  test('should call native signalUnknownCredential method', async () => {
+    const signalSpy = jest
+      .spyOn(NativeModules.Passkey, 'signalUnknownCredential')
+      .mockResolvedValue(undefined);
+
+    await Passkey.signalUnknownCredential({
+      rpId: 'example.com',
+      credentialId: 'Y3JlZA',
+    });
+    expect(signalSpy).toHaveBeenCalledWith('example.com', 'Y3JlZA');
+  });
+
+  test('should call native signalAllAcceptedCredentials method with stringified ids', async () => {
+    const signalSpy = jest
+      .spyOn(NativeModules.Passkey, 'signalAllAcceptedCredentials')
+      .mockResolvedValue(undefined);
+
+    await Passkey.signalAllAcceptedCredentials({
+      rpId: 'example.com',
+      userId: 'dXNlcg',
+      allAcceptedCredentialIds: ['a', 'b'],
+    });
+    expect(signalSpy).toHaveBeenCalledWith(
+      'example.com',
+      'dXNlcg',
+      JSON.stringify(['a', 'b'])
+    );
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import type {
   PasskeyCreateResult,
   PasskeyGetRequest,
   PasskeyGetResult,
+  PasskeySignalUnknownCredentialRequest,
+  PasskeySignalAllAcceptedCredentialsRequest,
 } from './PasskeyTypes';
 
 export {
@@ -14,4 +16,6 @@ export {
   PasskeyCreateResult,
   PasskeyGetRequest,
   PasskeyGetResult,
+  PasskeySignalUnknownCredentialRequest,
+  PasskeySignalAllAcceptedCredentialsRequest,
 };


### PR DESCRIPTION
## Summary

Adds the [WebAuthn Signal API](https://w3c.github.io/webauthn/#sctn-signal-methods) to the package so apps can keep OS credential managers (iCloud Keychain, Google Password Manager, …) in sync with their server — removing/hiding passkeys the server has revoked or deleted.

Two methods are added to `Passkey`:

- **`Passkey.signalUnknownCredential({ rpId, credentialId })`** — reports a single credential the relying party no longer recognizes. Safe to call **unauthenticated** (e.g. after a failed sign-in): it takes only a credential id and no user handle.
- **`Passkey.signalAllAcceptedCredentials({ rpId, userId, allAcceptedCredentialIds })`** — reports the complete set of credential ids still accepted for a user; the OS removes/hides any stored credential not in the list (reversible; an empty list hides all). Use when **authenticated** to authoritatively prune.

Both are **best-effort**: they resolve once the request is accepted and **no-op** on OS versions without Signal API support. Credential ids and the user handle are Base64URL strings.

## Implementation

- **JS/TS** — two static methods on `Passkey` plus exported request types `PasskeySignalUnknownCredentialRequest` / `PasskeySignalAllAcceptedCredentialsRequest`.
- **iOS** — `ASCredentialUpdater.reportUnknownPublicKeyCredential` / `reportAllAcceptedPublicKeyCredentials`, guarded by `#available(iOS 26.0, *)` (no-ops below). Reuses the existing `Data(base64URLEncoded:)` helper.
- **Android** — `CredentialManager.signalCredentialState` with `SignalUnknownCredentialRequest` / `SignalAllAcceptedCredentialIdsRequest`. This requires bumping `androidx.credentials` 1.5.0 → 1.6.0 (the release that ships these classes).
- **Docs** — new "Signal API" section in the README.
- **Tests** — unit tests on both the iOS and Android specs verifying the native bridge is called with the right arguments (including that `allAcceptedCredentialIds` is JSON-stringified).

## Notes for reviewers

- **iOS build requirement:** `ASCredentialUpdater` needs the iOS 26 SDK at compile time. The podspec deployment target stays at 15.0 and the `#available` guard handles runtime, but CI must build with an Xcode that has the iOS 26 SDK.
- `signalCurrentUserDetails` is intentionally **not** included in this PR; it can be added in a follow-up.

## Test plan

- [x] `yarn lint`
- [x] `yarn typescript`
- [x] `yarn test` (13 passed)
- [x] `yarn prepare` (`bob build`)
