### PR TITLE
fix: propagate native error message instead of discarding it

### DIFF
--- a/android/src/main/java/com/reactnativepasskey/PasskeyModule.kt
+++ b/android/src/main/java/com/reactnativepasskey/PasskeyModule.kt
@@ -43,7 +43,9 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
         promise.resolve(response)
       } catch (e: CreateCredentialException) {
         val errorCode = handleRegistrationException(e)
-        promise.reject(errorCode, errorCode)
+        promise.reject(errorCode, e.errorMessage?.toString() ?: errorCode)
+      } catch (e: Throwable) {
+        promise.reject("UnknownError", e.message ?: "UnknownError")
       }
     }
   }
@@ -97,7 +99,9 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
           promise.resolve(response)
         } catch (e: GetCredentialException) {
           val errorCode = handleAuthenticationException(e)
-          promise.reject(errorCode, errorCode)
+          promise.reject(errorCode, e.errorMessage?.toString() ?: errorCode)
+        } catch (e: Throwable) {
+          promise.reject("UnknownError", e.message ?: "UnknownError")
         }
       }
   }

--- a/ios/Passkey.swift
+++ b/ios/Passkey.swift
@@ -94,7 +94,7 @@ class Passkey: NSObject, RNPasskeyResultHandler {
       passkeyDelegate.performAuthForController(controller: authController, preferImmediatelyAvailable: preferImmediatelyAvailable);
 
     } catch let error as NSError {
-      reject(error.debugDescription, error.debugDescription, nil);
+      handleError(handleErrorCode(error: error));
     }
   }
   

--- a/src/PasskeyError.ts
+++ b/src/PasskeyError.ts
@@ -70,6 +70,7 @@ export const NativeError = (
 
 export interface TNativeError {
   code?: string;
+  message?: string;
 }
 
 export function handleNativeError(_error: TNativeError): PasskeyError {
@@ -77,7 +78,25 @@ export function handleNativeError(_error: TNativeError): PasskeyError {
     return UnknownError;
   }
 
-  switch (_error.code) {
+  const mappedError = mapNativeErrorCode(_error.code, _error);
+
+  // Preserve the native error message (e.g. "RP ID cannot be validated.")
+  // when it carries more detail than the coarse error code, so callers can
+  // diagnose configuration problems instead of only seeing the generic
+  // fallback message for the mapped code.
+  if (
+    typeof _error.message === 'string' &&
+    _error.message.length > 0 &&
+    _error.message !== _error.code
+  ) {
+    return { ...mappedError, message: _error.message };
+  }
+
+  return mappedError;
+}
+
+function mapNativeErrorCode(code: string, _error: TNativeError): PasskeyError {
+  switch (code) {
     case 'NotSupported': {
       return NotSupportedError;
     }


### PR DESCRIPTION
## Problem

On Android, `create()` / `get()` reject with the coarse mapped error code as **both** the code and the message:

```kotlin
promise.reject(errorCode, errorCode)
```

This discards the real `CreateCredentialException.errorMessage` (e.g. `"RP ID cannot be validated."`). The JS wrapper (`handleNativeError`) then maps the code to a hardcoded generic string, so callers only ever see something like *"The request failed. No Credentials were returned."* — misleading, and useless for diagnosing configuration problems (RP ID / assetlinks mismatches, etc.).

Several distinct DOM errors (`NotAllowedError`, `DataError` = "RP ID cannot be validated", `SecurityError`) all collapse to `RequestFailed`, so the code alone cannot tell them apart — the message is the only signal, and it was being thrown away.

There was also no fallback `catch` around the coroutine body, so a non-`CredentialException` failure could leave the promise unsettled (a hang).

## Fix

Non-breaking — **error codes are unchanged**, so programmatic `.error === 'RequestFailed'` checks keep working. Only the message now carries the native detail.

- **Android** (`PasskeyModule.kt`): reject with the native message while keeping the code:
  ```kotlin
  promise.reject(errorCode, e.errorMessage?.toString() ?: errorCode)
  ```
  for both `create()` and `get()`, plus a `catch (e: Throwable)` fallback so unexpected failures reject with detail instead of hanging.
- **iOS** (`Passkey.swift`): the primary error path already propagated `error.localizedDescription`. Aligned the `get()` decode-`catch` with `create()` so it rejects with a mapped code + `localizedDescription` instead of the verbose `debugDescription` for both fields.
- **JS** (`PasskeyError.ts`): prefer the native message over the generic per-code fallback when it carries additional detail; fall back to the existing generic message otherwise. Added `message?: string` to `TNativeError`.

## Before / After

Given a native failure with `errorMessage = "RP ID cannot be validated."`:

- **Before:** `{ error: 'RequestFailed', message: 'The request failed. No Credentials were returned.' }`
- **After:** `{ error: 'RequestFailed', message: 'RP ID cannot be validated.' }`

## Verification

`yarn tsc --noEmit`, `eslint`, and the Jest suite all pass. Kotlin/Swift were not compiled in isolation but the edits are syntactically consistent with the surrounding code and existing imports.

## Related

- Fixes #68 ("[50152] RP ID cannot be validated on Android") — the underlying message is now surfaced to callers.
- Related to error-normalization discussion in #106 / #108 — this keeps the normalized codes but stops discarding the native detail.