### PR TITLE
fix(android): return stable error codes instead of localized messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The library normalises native error codes into the following set:
 | `BadConfiguration`   | App is not configured correctly (associated domain / asset links)      |
 | `NoCredentials`      | No credential is available — also returned for silent `getImmediate()` |
 | `CredentialAlreadyExists` | A passkey already exists for this account on this device (registration) |
+| `NoCreateOption`     | No credential provider can create a passkey (Android; e.g. no Google account signed in) |
 | `Interrupted`        | The operation was interrupted and may be retried                       |
 | `TimedOut`           | The operation timed out                                                |
 | `UnknownError`       | Unknown / unmapped error                                               |

--- a/android/src/main/java/com/reactnativepasskey/PasskeyModule.kt
+++ b/android/src/main/java/com/reactnativepasskey/PasskeyModule.kt
@@ -69,8 +69,17 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
       is CreateCredentialUnsupportedException -> {
         return "NotSupported"
       }
+      is CreateCredentialNoCreateOptionException -> {
+        // No credential provider offered to create a passkey — e.g. Google Password Manager
+        // with no Google account signed in, or no provider installed at all. Without a stable
+        // code here the JS side only receives the localized errorMessage, which it cannot
+        // branch on to offer a password fallback.
+        return "NoCreateOption"
+      }
       else -> {
-        return e.errorMessage.toString()
+        // Fall back to the androidx type constant rather than the human-readable message:
+        // `type` is a stable identifier, `errorMessage` is display text that may change.
+        return e.type
       }
     }
   }
@@ -127,7 +136,8 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
         return "NoCredentials"
       }
       else -> {
-        return e.errorMessage.toString()
+        // Stable identifier over display text, same rationale as the create path.
+        return e.type
       }
     }
   }

--- a/src/PasskeyError.ts
+++ b/src/PasskeyError.ts
@@ -59,6 +59,12 @@ export const CredentialAlreadyExistsError: PasskeyError = {
   message: 'A passkey for this account already exists on this device.',
 };
 
+export const NoCreateOptionError: PasskeyError = {
+  error: 'NoCreateOption',
+  message:
+    'No credential provider is available to create a passkey on this device.',
+};
+
 export const NativeError = (
   message = 'An unknown error occurred'
 ): PasskeyError => {
@@ -104,6 +110,9 @@ export function handleNativeError(_error: TNativeError): PasskeyError {
     }
     case 'CredentialAlreadyExists': {
       return CredentialAlreadyExistsError;
+    }
+    case 'NoCreateOption': {
+      return NoCreateOptionError;
     }
     case 'UnknownError': {
       return UnknownError;

--- a/src/__tests__/PasskeyAndroid.spec.ts
+++ b/src/__tests__/PasskeyAndroid.spec.ts
@@ -73,6 +73,21 @@ describe('Test Passkey Module', () => {
     );
   });
 
+  test('should surface NoCreateOption when no provider can create a passkey', async () => {
+    // Credential Manager raises CreateCredentialNoCreateOptionException when no credential
+    // provider offers to create one — most commonly Google Password Manager with no Google
+    // account signed in. Without an explicit mapping this fell through to `NativeError`,
+    // whose `error` is the generic 'Native error', so callers could not detect the state to
+    // fall back to a password flow.
+    jest
+      .spyOn(NativeModules.Passkey, 'create')
+      .mockRejectedValue({ code: 'NoCreateOption' });
+
+    await expect(Passkey.create(RegRequest)).rejects.toMatchObject({
+      error: 'NoCreateOption',
+    });
+  });
+
   test('should call native auth method', async () => {
     const authSpy = jest
       .spyOn(NativeModules.Passkey, 'get')


### PR DESCRIPTION
### Problem

Both Android exception handlers fall through to the localized message:

```kotlin
// handleRegistrationException / handleAuthenticationException
else -> { return e.errorMessage.toString() }
```

`errorMessage` is human-readable display text, so anything not explicitly mapped
reaches JS as an unmatchable string. `CreateCredentialException` already exposes a
stable `type` (verified against `androidx.credentials:1.5.0`).

The case that surfaced this: **`CreateCredentialNoCreateOptionException`**, which
Credential Manager throws when no provider will create a passkey — most commonly
Google Password Manager with no Google account signed in, or a device with no
provider installed. That's a reachable real-world state, and apps currently can't
detect it to offer a password fallback; they only get
`"No create options available."`.

### Change

- Map `CreateCredentialNoCreateOptionException` → `"NoCreateOption"`, matching the
  existing naming style (`NoCredentials`, `UserCancelled`, `NotSupported`).
- Replace both `else` branches with `e.type` (stable identifier) instead of
  `e.errorMessage` (display text).
- Add `NoCreateOptionError` + the `handleNativeError` case, so the code survives the
  JS layer rather than being swallowed by `default` → `NativeError`.
- Document it in the README error-code table.

### Notes

This follows the same shape as previously accepted mappings (#97 `CredentialAlreadyExists`,
#86 iOS 1001 → `UserCancelled`). Native-only + a JS switch case; no API breakage — the
`else` branch previously returned an unspecified string, so nothing could have depended
on its value.

Verified on an Android emulator (API 36, `google_apis_playstore`): without a Google
account the create call now rejects with `NoCreateOption`; after signing in, passkey
creation completes normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)