### PR TITLE
fix(ios): distinguish user cancel from no-credential in getImmediate

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ with a credential picker if no passkey exists.
 When no credential is available the call rejects with a `NoCredentials` error
 and no UI is shown. Handle this error to fall back to your usual sign-in flow.
 
+If a credential *was* available and the user dismissed the sheet, the call
+rejects with `UserCancelled` instead. The two are distinct on both platforms, so
+`UserCancelled` from `getImmediate()` is a reliable signal that the device holds
+a passkey for your relying party — useful for deciding whether to offer a
+"Sign in with passkey" retry after a dismissal.
+
 ```ts
 import { Passkey } from 'react-native-passkey';
 

--- a/ios/Passkey.swift
+++ b/ios/Passkey.swift
@@ -384,10 +384,19 @@ class Passkey: NSObject, RNPasskeyResultHandler {
       case 1001:
       // Immediate (silent) mediation reports "no credential available" as
       // ASAuthorizationError.canceled (1001), indistinguishable by code from a
-      // genuine user cancel. When we initiated an immediate request (iOS 16+),
-      // interpret it as NoCredentials so getImmediate() behaves as a silent probe.
+      // genuine user cancel. Disambiguate on whether the system asked us for a
+      // presentation anchor: it only does so when it is about to show the
+      // credential sheet, and under immediate mediation it only shows the sheet
+      // when a credential exists. So an anchor request means the user saw the
+      // sheet and dismissed it; no anchor request means the probe found nothing
+      // and failed silently, which is what getImmediate() promises.
+      //
+      // This keeps iOS consistent with Android, where Credential Manager already
+      // separates GetCredentialCancellationException from NoCredentialException.
       if preferImmediatelyAvailable, #available(iOS 16.0, *) {
-        return RNPasskeyError(type: .noCredentials, message: error.localizedDescription);
+        if passkeyDelegate?.didRequestPresentationAnchor != true {
+          return RNPasskeyError(type: .noCredentials, message: error.localizedDescription);
+        }
       }
       return RNPasskeyError(type: .cancelled, message: error.localizedDescription);
       case 1004:

--- a/ios/PasskeyDelegate.swift
+++ b/ios/PasskeyDelegate.swift
@@ -12,16 +12,31 @@ protocol RNPasskeyResultHandler {
 @available(iOS 15.0, *)
 class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
   private let _completionHandler: RNPasskeyResultHandler
-  
+
+  /**
+   Whether the system asked us for a window to present the credential sheet in.
+
+   The system only requests a presentation anchor when it is about to show UI,
+   and under immediate (silent) mediation it only shows UI when a credential is
+   actually available. That makes this the signal separating "the user dismissed
+   the sheet" from "the request failed before anything appeared" — two outcomes
+   iOS otherwise reports identically as ASAuthorizationError.canceled (1001).
+   See `Passkey.handleErrorCode`.
+   */
+  private(set) var didRequestPresentationAnchor: Bool = false;
+
   // Initializes delegate with a completion handler (callback function)
   init(completionHandler: RNPasskeyResultHandler) {
     _completionHandler = completionHandler;
   }
-  
+
   // Perform the authorization request for a given ASAuthorizationController instance
   func performAuthForController(controller: ASAuthorizationController, preferImmediatelyAvailable: Bool = false) {
     controller.delegate = self;
     controller.presentationContextProvider = self;
+    // A delegate is created per request, but reset defensively so a reused
+    // instance can never carry a stale "UI was shown" verdict into a new one.
+    didRequestPresentationAnchor = false;
     if preferImmediatelyAvailable {
       if #available(iOS 16.0, *) {
         controller.performRequests(options: .preferImmediatelyAvailableCredentials);
@@ -32,8 +47,9 @@ class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate, ASAuthorizat
       controller.performRequests();
     }
   }
-  
+
   func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+    didRequestPresentationAnchor = true;
     return UIApplication
       .shared
       .connectedScenes

--- a/src/__tests__/PasskeyiOS.spec.ts
+++ b/src/__tests__/PasskeyiOS.spec.ts
@@ -104,4 +104,19 @@ describe('Test Passkey Module', () => {
 
     await expect(Passkey.get(AuthRequest)).rejects.toEqual(UserCancelledError);
   });
+
+  // iOS reports both "no credential available" and a genuine dismissal as
+  // ASAuthorizationError.canceled (1001) under immediate mediation; the native
+  // layer separates them on whether a presentation anchor was requested. A
+  // dismissal must stay UserCancelled so callers can tell that the device does
+  // hold a passkey, matching Android's Credential Manager behaviour.
+  test('should reject getImmediate with UserCancelled when the user dismisses the sheet', async () => {
+    jest
+      .spyOn(NativeModules.Passkey, 'get')
+      .mockRejectedValue({ code: 'UserCancelled' });
+
+    await expect(Passkey.getImmediate(AuthRequest)).rejects.toEqual(
+      UserCancelledError
+    );
+  });
 });


### PR DESCRIPTION
### Problem
On iOS, getImmediate() can never reject with UserCancelled. Since #108, a 1001 under immediate mediation is unconditionally mapped to NoCredentials, so a user dismissing the sheet is indistinguishable from a device with no passkey.

That matters for the exact use case getImmediate() was added for. An app that probes on its sign-in screen wants to offer a "Sign in with passkey" retry after a dismissal — but only to users who actually have one. On Android that works today; on iOS it can't.

### Approach
ASAuthorizationControllerPresentationContextProviding.presentationAnchor(for:) is only invoked when the system is about to present UI, and immediate mediation only presents when a credential is available. Recording whether the anchor was requested recovers the distinction without heuristics or timing.
- PasskeyDelegate exposes didRequestPresentationAnchor, set in presentationAnchor(for:) and reset in performAuthForController
- Passkey.handleErrorCode branches on it for 1001 under immediate mediation
- Non-immediate get() and create() are untouched

### Testing
Verified on device against a real RP:
- passkey present, sheet dismissed → UserCancelled
- no passkey → NoCredentials, no UI shown

Adds a JS test pinning getImmediate → UserCancelled on dismissal, alongside the existing NoCredentials case.
