### PR TITLE
fix(ios): detect no-credential from the error's failure reason

### DIFF
--- a/ios/Passkey.swift
+++ b/ios/Passkey.swift
@@ -379,20 +379,36 @@ class Passkey: NSObject, RNPasskeyResultHandler {
    Handles ASAuthorization error codes
   */
   private func handleErrorCode(error: Error) -> RNPasskeyError {
-    let errorCode = (error as NSError).code;
+    let nsError = error as NSError;
+    let errorCode = nsError.code;
     switch errorCode {
       case 1001:
       // Immediate (silent) mediation reports "no credential available" as
-      // ASAuthorizationError.canceled (1001), indistinguishable by code from a
-      // genuine user cancel. Disambiguate on whether the system asked us for a
-      // presentation anchor: it only does so when it is about to show the
-      // credential sheet, and under immediate mediation it only shows the sheet
-      // when a credential exists. So an anchor request means the user saw the
-      // sheet and dismissed it; no anchor request means the probe found nothing
-      // and failed silently, which is what getImmediate() promises.
+      // ASAuthorizationError.canceled (1001), indistinguishable *by code* from a
+      // genuine user cancel. iOS separates them in whether the error carries a
+      // failure reason:
+      //
+      //   no credential   NSLocalizedFailureReasonErrorKey = "No credentials available for login."
+      //                   -> localizedDescription = "The operation couldn't be completed. <reason>"
+      //   genuine cancel  no failure reason, and userInfo is empty
+      //                   -> localizedDescription = "The operation couldn't be completed. (domain
+      //                      error code.)", Foundation's generic fallback
+      //
+      // It is the *presence* of the reason that is the signal, never its text, so this stays
+      // locale-independent. Verified against both outcomes on iOS 26.5 (simulator) and 26.6 (device).
       //
       // This keeps iOS consistent with Android, where Credential Manager already
       // separates GetCredentialCancellationException from NoCredentialException.
+      if preferImmediatelyAvailable, nsError.localizedFailureReason != nil {
+        return RNPasskeyError(type: .noCredentials, message: error.localizedDescription);
+      }
+      // Fallback for OS versions that do not populate the failure reason. The system only asks for a
+      // presentation anchor when it is about to show the credential sheet, and under immediate
+      // mediation it only shows the sheet when a credential exists — so no anchor request means the
+      // probe found nothing and failed silently, which is what getImmediate() promises.
+      //
+      // Not the primary signal: on iOS 26 the anchor is requested either way, even when nothing is
+      // presented, so this check cannot discriminate there.
       if preferImmediatelyAvailable, #available(iOS 16.0, *) {
         if passkeyDelegate?.didRequestPresentationAnchor != true {
           return RNPasskeyError(type: .noCredentials, message: error.localizedDescription);


### PR DESCRIPTION
## Summary

  Follow-up to #111. The presentation-anchor heuristic I added there does not hold on
  iOS 26, so `getImmediate()` can no longer report `NoCredentials` on the current OS —
  every `ASAuthorizationError.canceled` (1001) is classified as `UserCancelled`,
  including the silent no-credential case the API exists to surface.

  This replaces the primary signal with one iOS provides directly, and keeps the anchor
  check as a fallback.

  ## The problem

  `#111` disambiguated 1001 on the assumption that the system only requests a
  presentation anchor when it is about to show the credential sheet, and that under
  immediate mediation it only shows the sheet when a credential exists. On iOS 26 the
  first half of that no longer holds: the anchor is requested during request setup,
  before the system knows whether it has anything to present.

  `didRequestPresentationAnchor` is therefore `true` for both outcomes, the check can
  never discriminate, and control always falls through to `.cancelled`.

  Consumer impact: a silent probe against a device with no credential looks like a user
  dismissal. In our app that meant offering a "Sign in with passkey" button on a device
  that has none, and recording a spurious cancellation in analytics.

  ## Root cause and the signal used instead

  iOS distinguishes the two itself, in whether the error carries a failure reason:

  | case | `localizedFailureReason` | `userInfo` |
  | --- | --- | --- |
  | no credential | `"No credentials available for login."` | `["NSLocalizedFailureReason"]` |
  | genuine cancel | `nil` | `[]` |

  `localizedDescription` reflects that too — the no-credential case composes
  `"The operation couldn't be completed. <reason>"`, while a genuine cancel gets
  Foundation's generic `"The operation couldn't be completed. (domain error code.)"`
  fallback.

  The check keys off the **presence** of the reason, never its text, so it stays
  locale-independent.

  ## Measurements

  Both outcomes, on each of iOS 26.5 (simulator) and iOS 26.6 (physical device) —
  four runs, consistent:

      case            anchor  failureReason  userInfo keys
      no credential   true    set            [NSLocalizedFailureReason]
      genuine cancel  true    nil            []

  `anchor=true` in all four is the finding: on iOS 26 the anchor signal carries no
  information.

  ## Backwards compatibility

  - The anchor check is **kept**, after the new one. On iOS 26 it is unreachable; on any
    OS that does not populate a failure reason it still does the work it did before, so
    behaviour there is unchanged.
  - Both checks remain gated on `preferImmediatelyAvailable`, so the normal interactive
    `get()` path is untouched.
  - No Android change. Credential Manager already separates
    `GetCredentialCancellationException` from `NoCredentialException`.
  - No public API change.

  ## Testing

  Manually, against a real relying party, on iOS 26.5 (simulator) and 26.6 (device):

  - `getImmediate()` with no credential on the device → rejects `NoCredentials`, no UI shown
  - `getImmediate()` with a credential present, sheet dismissed by the user → rejects `UserCancelled`
  - Interactive `get()` cancelled → rejects `UserCancelled`, unchanged
