### PR TITLE
fix: preserve native user and configuration error codes

### DIFF
--- a/src/PasskeyError.ts
+++ b/src/PasskeyError.ts
@@ -79,8 +79,10 @@ export interface TNativeError {
   message?: string;
 }
 
-export function handleNativeError(_error: TNativeError): PasskeyError {
-  if (!_error.code) {
+export function handleNativeError(
+  _error: TNativeError | null | undefined
+): PasskeyError {
+  if (!_error?.code) {
     return UnknownError;
   }
 
@@ -115,6 +117,11 @@ function mapNativeErrorCode(code: string, _error: TNativeError): PasskeyError {
     case 'InvalidChallenge': {
       return InvalidChallengeError;
     }
+    case 'InvalidUser':
+    case 'InvalidUserId': {
+      return InvalidUserIdError;
+    }
+    case 'NotConfigured':
     case 'BadConfiguration': {
       return BadConfiguration;
     }


### PR DESCRIPTION
## Fixes

- Map iOS InvalidUser and InvalidUserId to the existing InvalidUserId error.
- Map Android NotConfigured to the existing BadConfiguration error.
- Handle null/undefined rejection values with UnknownError instead of throwing a secondary TypeError.

Preserve detailed native messages and the existing error object shape. Consumers now receive the intended stable categories instead of generic Native error for these known codes; this observable correction is intentional.

## Verification

Inline before/after checks reproduce both nullish TypeErrors and the three generic-code fallthroughs; all now map correctly. Baseline and combined fixes pass all 30 existing tests, TypeScript, full lint and CommonJS/ESM/declaration builds. No tests changed; no live authentication requests.

