### PR TITLE
fix(android): contain setup errors and cancel invalidated passkey work

### DIFF
--- a/android/src/main/java/com/reactnativepasskey/PasskeyModule.kt
+++ b/android/src/main/java/com/reactnativepasskey/PasskeyModule.kt
@@ -18,6 +18,8 @@ import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentia
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 import org.json.JSONArray
@@ -30,13 +32,17 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
     return "Passkey"
   }
 
+  override fun invalidate() {
+    mainScope.cancel()
+    super.invalidate()
+  }
+
   @ReactMethod
   fun create(requestJson: String, forcePlatformKey: Boolean, forceSecurityKey: Boolean, promise: Promise) {
-    val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
-    val createPublicKeyCredentialRequest = CreatePublicKeyCredentialRequest(requestJson)
-
     mainScope.launch {
       try {
+        val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
+        val createPublicKeyCredentialRequest = CreatePublicKeyCredentialRequest(requestJson)
         val activity = reactApplicationContext.currentActivity
           ?: run { promise.reject("RequestFailed", "No active Activity"); return@launch }
 
@@ -49,6 +55,8 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
       } catch (e: CreateCredentialException) {
         val errorCode = handleRegistrationException(e)
         promise.reject(errorCode, e.errorMessage?.toString() ?: errorCode)
+      } catch (e: CancellationException) {
+        throw e
       } catch (e: Throwable) {
         promise.reject("UnknownError", e.message ?: "UnknownError")
       }
@@ -93,15 +101,14 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
 
   @ReactMethod
   fun get(requestJson: String, forcePlatformKey: Boolean, forceSecurityKey: Boolean, preferImmediatelyAvailable: Boolean, promise: Promise) {
-      val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
-      val getCredentialRequest =
-        GetCredentialRequest(
-          listOf(GetPublicKeyCredentialOption(requestJson)),
-          preferImmediatelyAvailableCredentials = preferImmediatelyAvailable
-        )
-
       mainScope.launch {
         try {
+          val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
+          val getCredentialRequest =
+            GetCredentialRequest(
+              listOf(GetPublicKeyCredentialOption(requestJson)),
+              preferImmediatelyAvailableCredentials = preferImmediatelyAvailable
+            )
           val activity = reactApplicationContext.currentActivity
             ?: run { promise.reject("RequestFailed", "No active Activity"); return@launch }
 
@@ -114,6 +121,8 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
         } catch (e: GetCredentialException) {
           val errorCode = handleAuthenticationException(e)
           promise.reject(errorCode, e.errorMessage?.toString() ?: errorCode)
+        } catch (e: CancellationException) {
+          throw e
         } catch (e: Throwable) {
           promise.reject("UnknownError", e.message ?: "UnknownError")
         }
@@ -130,16 +139,17 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
    */
   @ReactMethod
   fun signalUnknownCredential(rpId: String, credentialId: String, promise: Promise) {
-    val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
-    val requestJson = JSONObject().apply {
-      put("rpId", rpId)
-      put("credentialId", credentialId)
-    }.toString()
-
     mainScope.launch {
       try {
+        val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
+        val requestJson = JSONObject().apply {
+          put("rpId", rpId)
+          put("credentialId", credentialId)
+        }.toString()
         credentialManager.signalCredentialState(SignalUnknownCredentialRequest(requestJson))
         promise.resolve(null)
+      } catch (e: CancellationException) {
+        throw e
       } catch (e: Exception) {
         promise.reject("SignalFailed", e.message ?: "signalUnknownCredential failed", e)
       }
@@ -162,17 +172,18 @@ class PasskeyModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
     allAcceptedCredentialIdsJson: String,
     promise: Promise
   ) {
-    val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
-    val requestJson = JSONObject().apply {
-      put("rpId", rpId)
-      put("userId", userId)
-      put("allAcceptedCredentialIds", JSONArray(allAcceptedCredentialIdsJson))
-    }.toString()
-
     mainScope.launch {
       try {
+        val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
+        val requestJson = JSONObject().apply {
+          put("rpId", rpId)
+          put("userId", userId)
+          put("allAcceptedCredentialIds", JSONArray(allAcceptedCredentialIdsJson))
+        }.toString()
         credentialManager.signalCredentialState(SignalAllAcceptedCredentialIdsRequest(requestJson))
         promise.resolve(null)
+      } catch (e: CancellationException) {
+        throw e
       } catch (e: Exception) {
         promise.reject("SignalFailed", e.message ?: "signalAllAcceptedCredentials failed", e)
       }


### PR DESCRIPTION
## Fixes

- Construct CredentialManager and create/get request objects inside the coroutine's existing try/catch, so setup/JSON validation failures reject the promise instead of escaping the bridge method.
- Put Signal API JSON construction in the same protected scope.
- Cancel the module's coroutine scope from invalidate; rethrow coroutine cancellation rather than reporting it to a disposed React instance as an ordinary provider error.

Public signatures, successful payloads, provider-specific error mapping and authenticator flags are unchanged. Setup failures now reject through the existing error paths. Module teardown cancels outstanding work; no stale completion is promised after teardown.

## Verification

The combined reviewed changes pass all 30 existing JS tests, TypeScript, full lint, package builds and whitespace checks. No tests were written or changed. Native consumer checks on RN 0.87.1 pass: both Android Debug flavors, both iOS simulator Debug schemes, and all four release-mode Metro bundles. Existing JS tests mock the native module: they are not proof of real Credential Manager/provider behavior, and no live credential creation/get/Signal API operation was performed.
